### PR TITLE
Fix navigation bar height applied as start, top, end and bottom padding

### DIFF
--- a/ui/src/main/java/com/jeanbarrossilva/memento/ui/theme/sizes/SizesProvider.kt
+++ b/ui/src/main/java/com/jeanbarrossilva/memento/ui/theme/sizes/SizesProvider.kt
@@ -21,7 +21,7 @@ internal fun SizesProvider(content: @Composable () -> Unit) {
             Margin(
                 statusBar = PaddingValues(top = statusBarHeight()),
                 fab = PaddingValues(bottom = navigationBarHeight() + 16.dp * 2 + 56.dp),
-                navigationBar = PaddingValues(navigationBarHeight())
+                navigationBar = PaddingValues(bottom = navigationBarHeight())
             )
         ),
         content = content


### PR DESCRIPTION
Should only be applied as a bottom padding.