### PR TITLE
Add scope as a param of the menu drawer

### DIFF
--- a/ui/src/main/java/com/jeanbarrossilva/memento/ui/component/scaffold/menudrawer/MenuDrawer.kt
+++ b/ui/src/main/java/com/jeanbarrossilva/memento/ui/component/scaffold/menudrawer/MenuDrawer.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.ThumbUp
-import androidx.compose.material.rememberSwipeableState
 import androidx.compose.material.swipeable
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -55,14 +54,11 @@ fun MenuDrawer(
     title: @Composable () -> Unit,
     items: @Composable ColumnScope.() -> Unit,
     modifier: Modifier = Modifier,
+    scope: MenuDrawerScope = rememberMenuDrawerScope(),
     content: @Composable MenuDrawerScope.() -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
-
-    @Suppress("SpellCheckingInspection")
-    val swipeableState =
-        rememberSwipeableState(initialValue = DrawerValue.Closed, MementoTheme.animation.spec())
-
+    val swipeableState = scope.swipeableState
     var menuDrawerWidth by remember { mutableStateOf<MenuDrawerWidth>(MenuDrawerWidth.Unspecified) }
     val menuDrawerScope = SwipeableMenuDrawerScope(swipeableState)
     val isMenuDrawerOpen = swipeableState.currentValue == DrawerValue.Open

--- a/ui/src/main/java/com/jeanbarrossilva/memento/ui/component/scaffold/menudrawer/MenuDrawerScope.extensions.kt
+++ b/ui/src/main/java/com/jeanbarrossilva/memento/ui/component/scaffold/menudrawer/MenuDrawerScope.extensions.kt
@@ -1,0 +1,18 @@
+package com.jeanbarrossilva.memento.ui.component.scaffold.menudrawer // ktlint-disable filename
+
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.rememberSwipeableState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.jeanbarrossilva.memento.ui.theme.MementoTheme
+
+/** Creates a [MenuDrawerScope] and [remembers][remember] it. **/
+@Composable
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+fun rememberMenuDrawerScope(): MenuDrawerScope {
+    val swipeableState =
+        rememberSwipeableState(initialValue = DrawerValue.Closed, MementoTheme.animation.spec())
+    return remember { SwipeableMenuDrawerScope(swipeableState) }
+}

--- a/ui/src/main/java/com/jeanbarrossilva/memento/ui/component/scaffold/menudrawer/MenuDrawerScope.kt
+++ b/ui/src/main/java/com/jeanbarrossilva/memento/ui/component/scaffold/menudrawer/MenuDrawerScope.kt
@@ -1,7 +1,15 @@
 package com.jeanbarrossilva.memento.ui.component.scaffold.menudrawer
 
-interface MenuDrawerScope {
-    suspend fun open()
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.SwipeableState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ExperimentalMaterial3Api
 
-    suspend fun close()
+abstract class MenuDrawerScope internal constructor() {
+    @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+    internal abstract val swipeableState: SwipeableState<DrawerValue>
+
+    abstract suspend fun open()
+
+    abstract suspend fun close()
 }

--- a/ui/src/main/java/com/jeanbarrossilva/memento/ui/component/scaffold/menudrawer/SwipeableMenuDrawerScope.kt
+++ b/ui/src/main/java/com/jeanbarrossilva/memento/ui/component/scaffold/menudrawer/SwipeableMenuDrawerScope.kt
@@ -6,14 +6,13 @@ import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
-@Suppress("SpellCheckingInspection")
-internal class SwipeableMenuDrawerScope(private val state: SwipeableState<DrawerValue>) :
-    MenuDrawerScope {
+internal class SwipeableMenuDrawerScope(override val swipeableState: SwipeableState<DrawerValue>) :
+    MenuDrawerScope() {
     override suspend fun open() {
-        state.animateTo(DrawerValue.Open)
+        swipeableState.animateTo(DrawerValue.Open)
     }
 
     override suspend fun close() {
-        state.animateTo(DrawerValue.Closed)
+        swipeableState.animateTo(DrawerValue.Closed)
     }
 }


### PR DESCRIPTION
Allows external control over the `MenuDrawerScope`, such as opening and closing the drawer based on an action performed by the user.