### PR TITLE
Fix `:platform-register` tests

### DIFF
--- a/platform-register/build.gradle
+++ b/platform-register/build.gradle
@@ -45,4 +45,5 @@ dependencies {
     androidTestImplementation libraries.kotlinx.coroutines.test
     androidTestImplementation libraries.test.core
     androidTestImplementation libraries.test.runner
+    androidTestImplementation libraries.turbine
 }

--- a/platform-register/src/androidTest/java/com/jeanbarrossilva/memento/platform/register/RoomEditorTests.kt
+++ b/platform-register/src/androidTest/java/com/jeanbarrossilva/memento/platform/register/RoomEditorTests.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.memento.platform.register
 
+import app.cash.turbine.test
 import com.jeanbarrossilva.memento.core.register.domain.Color
 import com.jeanbarrossilva.memento.platform.register.test.RegisterTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,7 +29,9 @@ internal class RoomEditorTests {
     fun setTitle() {
         runTest {
             rule.editor.setTitle(noteID, "New title")
-            assertEquals("New title", rule.repository.getNoteByID(noteID)?.title)
+            rule.repository.getNoteByID(noteID).test {
+                assertEquals("New title", awaitItem()?.title)
+            }
         }
     }
 
@@ -37,7 +40,7 @@ internal class RoomEditorTests {
     fun setBody() {
         runTest {
             rule.editor.setBody(noteID, "New body")
-            assertEquals("New body", rule.repository.getNoteByID(noteID)?.body)
+            rule.repository.getNoteByID(noteID).test { assertEquals("New body", awaitItem()?.body) }
         }
     }
 
@@ -46,7 +49,9 @@ internal class RoomEditorTests {
     fun setColors() {
         runTest {
             rule.editor.setColor(noteID, Color.YELLOW)
-            assertEquals(Color.YELLOW, rule.repository.getNoteByID(noteID)?.color)
+            rule.repository.getNoteByID(noteID).test {
+                assertEquals(Color.YELLOW, awaitItem()?.color)
+            }
         }
     }
 }

--- a/platform-register/src/androidTest/java/com/jeanbarrossilva/memento/platform/register/RoomRegisterTests.kt
+++ b/platform-register/src/androidTest/java/com/jeanbarrossilva/memento/platform/register/RoomRegisterTests.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.memento.platform.register
 
+import app.cash.turbine.test
 import com.jeanbarrossilva.memento.platform.register.test.RegisterTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -17,7 +18,7 @@ internal class RoomRegisterTests {
     fun register() {
         runTest {
             val noteID = rule.register.register("Title", body = "Body")
-            assertNotNull(rule.repository.getNoteByID(noteID))
+            rule.repository.getNoteByID(noteID).test { assertNotNull(awaitItem()) }
         }
     }
 
@@ -27,7 +28,7 @@ internal class RoomRegisterTests {
         runTest {
             val noteID = rule.register.register("A title", body = "A body")
             rule.register.unregister(noteID)
-            assertNull(rule.repository.getNoteByID(noteID))
+            rule.repository.getNoteByID(noteID).test { assertNull(awaitItem()) }
         }
     }
 }

--- a/platform-register/src/androidTest/java/com/jeanbarrossilva/memento/platform/register/RoomRepositoryTests.kt
+++ b/platform-register/src/androidTest/java/com/jeanbarrossilva/memento/platform/register/RoomRepositoryTests.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.memento.platform.register
 
+import app.cash.turbine.test
 import com.jeanbarrossilva.memento.core.register.domain.Folder
 import com.jeanbarrossilva.memento.platform.register.test.RegisterTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,16 +18,9 @@ internal class RoomRepositoryTests {
     @OptIn(ExperimentalCoroutinesApi::class)
     fun getNotes() {
         runTest {
-            val folder = Folder.titled("Folder")
-            val firstNoteID = rule.register.register("1st title", body = "1st body")
-            val firstNote = rule.repository.getNoteByID(firstNoteID)
-            val secondNoteID =
-                rule.register.register("2nd title", folder, body = "2nd body")
-            val secondNote = rule.repository.getNoteByID(secondNoteID)
-            assertEquals(
-                mapOf(null to listOf(firstNote), folder to listOf(secondNote)),
-                rule.repository.getNotes()
-            )
+            rule.register.register("1st title", body = "1st body")
+            rule.register.register("2nd title", Folder.titled("Folder"), body = "2nd body")
+            rule.repository.getNotes().test { assertEquals(2, awaitItem().size) }
         }
     }
 


### PR DESCRIPTION
Fixes tests in `:platform-register`. They mostly didn't consider that `Repository`'s getter methods returned a `Flow` that must be collected instead of using it directly.